### PR TITLE
feat(bin): 本地部署时自动检查并创建 sandbox-network 网络

### DIFF
--- a/bin/magic.sh
+++ b/bin/magic.sh
@@ -277,6 +277,23 @@ if [ "$SKIP_INSTALLATION" = "false" ]; then
         fi
     }
 
+    # Check and create sandbox-network if it doesn't exist
+    check_and_create_network() {
+        NETWORK_NAME="sandbox-network"
+        if ! docker network ls | grep -q "$NETWORK_NAME"; then
+            bilingual "创建 $NETWORK_NAME 网络..." "Creating $NETWORK_NAME network..."
+            docker network create "$NETWORK_NAME"
+            if [ $? -eq 0 ]; then
+                bilingual "$NETWORK_NAME 网络创建成功。" "$NETWORK_NAME network created successfully."
+            else
+                bilingual "错误：无法创建 $NETWORK_NAME 网络。" "Error: Failed to create $NETWORK_NAME network."
+                exit 1
+            fi
+        else
+            bilingual "$NETWORK_NAME 网络已存在，跳过创建。" "$NETWORK_NAME network already exists, skipping creation."
+        fi
+    }
+
     # Detect public IP and update environment variables
     detect_public_ip() {
         # Ask user about deployment method
@@ -288,6 +305,7 @@ if [ "$SKIP_INSTALLATION" = "false" ]; then
         # If user chooses local deployment, do not update IP
         if [ "$DEPLOYMENT_TYPE" = "1" ]; then
             bilingual "已选择本地部署，保持默认设置。" "Local deployment selected, keeping default settings."
+            check_and_create_network  # 自动检查和创建 sandbox-network
             return 0
         elif [ "$DEPLOYMENT_TYPE" != "2" ]; then
             bilingual "无效的选项，默认使用本地部署。" "Invalid option, using local deployment by default."


### PR DESCRIPTION
- 新增 check_and_create_network 函数，用于检查和创建 sandbox-network 网络
- 在本地部署选项下调用该函数，确保网络存在
- 添加双语提示信息，提高用户体验