### PR TITLE
fix: remove Access-Control-Allow-Credentials header for CORS security compliance

### DIFF
--- a/backend/magic-service/app/Infrastructure/Util/Middleware/CorsMiddleware.php
+++ b/backend/magic-service/app/Infrastructure/Util/Middleware/CorsMiddleware.php
@@ -21,7 +21,6 @@ class CorsMiddleware implements MiddlewareInterface
         $response = Context::get(ResponseInterface::class);
         $response = $response
             ->withHeader('Access-Control-Allow-Origin', '*')
-            ->withHeader('Access-Control-Allow-Credentials', 'true')
             ->withHeader('Access-Control-Allow-Headers', 'DNT,Keep-Alive,User-Agent,Cache-Control,Content-Type,Authorization,application-code,organization-code,x-forwarded-user,token,request-id,Language,api-key')
             ->withHeader('Access-Control-Allow-Methods', '*')
             ->withHeader('Request-Id', CoContext::getOrSetRequestId());

--- a/backend/super-magic/app/api/middleware/options_middleware.py
+++ b/backend/super-magic/app/api/middleware/options_middleware.py
@@ -35,7 +35,6 @@ class OptionsMiddleware(BaseHTTPMiddleware):
             response.headers["Access-Control-Allow-Origin"] = "*"
             response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS, PATCH"
             response.headers["Access-Control-Allow-Headers"] = "*"
-            response.headers["Access-Control-Allow-Credentials"] = "true"
             response.headers["Access-Control-Max-Age"] = "3600"
             return response
 


### PR DESCRIPTION
根据 CORS 安全最佳实践，当 Access-Control-Allow-Origin 设置为 "*"（允许所有来源）时，
不应同时将 Access-Control-Allow-Credentials 设置为 "true"。这种组合会创建安全漏洞，
因为它可能允许任何网站向 API 发送带身份验证的请求。