### PR TITLE
docs: localize Chinese README badge alt text

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -9,7 +9,7 @@
 <div align="center">
   <p align="center">
     <a href="https://www.magicrew.ai" target="_blank">
-      <img alt="Static Badge" src="https://img.shields.io/badge/Official Website-301AD2">
+      <img alt="官方网站" src="https://img.shields.io/badge/Official Website-301AD2">
     </a>
     <a href="https://github.com/dtyq/magic/releases">
       <img src="https://poser.pugx.org/dtyq/magic/v/stable" alt="Stable Version">
@@ -24,7 +24,7 @@
       <img alt="Discussion posts" src="https://img.shields.io/github/discussions/dtyq/magic?labelColor=%20%239b8afb&color=%20%237a5af8">
     </a>
     <a href="https://www.magicrew.ai" target="_blank">
-      <img alt="Static Badge" src="https://img.shields.io/badge/Built with Magic 🔮-301AD2">
+      <img alt="基于 Magic 构建" src="https://img.shields.io/badge/Built with Magic 🔮-301AD2">
     </a>
   </p>
 </div>


### PR DESCRIPTION
## Summary\n- localize the first two badge  texts in \n\n## Why\nThe Chinese README is otherwise localized, but these badge alt texts are still generic English placeholders ("Static Badge"). This small docs accessibility polish improves consistency and makes the markup more descriptive for assistive technologies.\n\n## Verification\n- verified  now uses descriptive localized alt text for the first two badges